### PR TITLE
add project structure and update models with bq dataset references

### DIFF
--- a/models/Untitled-1.sql
+++ b/models/Untitled-1.sql
@@ -1,27 +1,28 @@
-// DDL for creating two tables
-CREATE OR REPLACE TABLE table1 (
-  id INT PRIMARY KEY,
-  name VARCHAR(50),
-  age INT,
-  timestamp TIMESTAMP_LTZ
-);
+SELECT * from bigquery-public-data.austin_311.311_service_requests
+-- DDL for creating two tables
+-- CREATE OR REPLACE TABLE table1 (
+--   id INT PRIMARY KEY,
+--   name VARCHAR(50),
+--   age INT,
+--   timestamp TIMESTAMP_LTZ
+-- );
 
-CREATE OR REPLACE TABLE table2 (
-  id INT PRIMARY KEY,
-  address VARCHAR(100),
-  phone VARCHAR(20),
-  timestamp TIMESTAMP_LTZ
-);
+-- CREATE OR REPLACE TABLE table2 (
+--   id INT PRIMARY KEY,
+--   address VARCHAR(100),
+--   phone VARCHAR(20),
+--   timestamp TIMESTAMP_LTZ
+-- );
 
-// DML to insert 100 records of sample data into each table
-INSERT INTO table1 (id, name, age, timestamp)
-VALUES
-  (1, 'John Doe', 25, current_timestamp),
-  (2, 'Jane Smith', 30, current_timestamp),
-  (3, 'Alice Johnson', 35, current_timestamp);
+-- -- DML to insert 100 records of sample data into each table
+-- INSERT INTO table1 (id, name, age, timestamp)
+-- VALUES
+--   (1, 'John Doe', 25, current_timestamp),
+--   (2, 'Jane Smith', 30, current_timestamp),
+--   (3, 'Alice Johnson', 35, current_timestamp);
 
-INSERT INTO table2 (id, address, phone, timestamp)
-VALUES
-  (1, '123 Main St', '555-1234', current_timestamp),
-  (2, '456 Elm St', '555-5678', current_timestamp),
-  (3, '789 Oak St', '555-9012', current_timestamp);
+-- INSERT INTO table2 (id, address, phone, timestamp)
+-- VALUES
+--   (1, '123 Main St', '555-1234', current_timestamp),
+--   (2, '456 Elm St', '555-5678', current_timestamp),
+--   (3, '789 Oak St', '555-9012', current_timestamp);

--- a/models/example/cur_table_1.sql
+++ b/models/example/cur_table_1.sql
@@ -1,4 +1,0 @@
--- FILEPATH: /Users/bigboss/Projects/DBT_ex/dbt_testing_project/models/example/cur_table_1.sql
-SELECT t1.id, name, age, address, phone, t1."timestamp" AS t1_ts, t2."timestamp" AS t2_ts
-FROM {{ ref("stg_table_1") }} AS t1
-LEFT JOIN {{ ref("stg_table_2") }} AS t2 ON t1.id = t2.id

--- a/models/example/schema.yml
+++ b/models/example/schema.yml
@@ -3,26 +3,10 @@ version: 2
 
 sources:
   - name: test_table_sources
-    schema: dbt_testing
+    database: bigquery-public-data
+    schema: austin_bikeshare
     tables: 
-      - name: table1
-      - name: table2
+      - name: bikeshare_stations
+      - name: bikeshare_trips
 
-models:
-  - name: my_first_dbt_model
-    description: "A starter dbt model"
-    columns:
-      - name: id
-        description: "The primary key for this table"
-        tests:
-          - unique
-          - not_null
-
-  - name: my_second_dbt_model
-    description: "A starter dbt model"
-    columns:
-      - name: id
-        description: "The primary key for this table"
-        tests:
-          - unique
-          - not_null
+            

--- a/models/example/stg_table_1.sql
+++ b/models/example/stg_table_1.sql
@@ -1,7 +1,6 @@
-
 {{ config(materialized='incremental') }}
 SELECT *
-FROM {{ source("test_table_sources", "table1") }}
+FROM {{ source("test_table_sources", "bikeshare_trips") }}
 {% if is_incremental() %}
-WHERE {{ source("test_table_sources", "table1" ) }}.timestamp > (SELECT MAX(timestamp) from {{ this }})
+WHERE {{ source("test_table_sources", "bikeshare_trips" ) }}.timestamp > (SELECT MAX(timestamp) from {{ this }})
 {% endif %}

--- a/models/example/stg_table_1.sql
+++ b/models/example/stg_table_1.sql
@@ -1,6 +1,0 @@
-{{ config(materialized='incremental') }}
-SELECT *
-FROM {{ source("test_table_sources", "bikeshare_trips") }}
-{% if is_incremental() %}
-WHERE {{ source("test_table_sources", "bikeshare_trips" ) }}.start_time > (SELECT MAX(start_time) from {{ this }})
-{% endif %}

--- a/models/example/stg_table_1.sql
+++ b/models/example/stg_table_1.sql
@@ -2,5 +2,5 @@
 SELECT *
 FROM {{ source("test_table_sources", "bikeshare_trips") }}
 {% if is_incremental() %}
-WHERE {{ source("test_table_sources", "bikeshare_trips" ) }}.timestamp > (SELECT MAX(timestamp) from {{ this }})
+WHERE {{ source("test_table_sources", "bikeshare_trips" ) }}.start_time > (SELECT MAX(start_time) from {{ this }})
 {% endif %}

--- a/models/example/stg_table_2.sql
+++ b/models/example/stg_table_2.sql
@@ -1,6 +1,0 @@
-{{ config(materialized='incremental') }}
-SELECT *
-FROM {{ source("test_table_sources", "bikeshare_stations" ) }}
-{% if is_incremental() %}
-WHERE {{ source("test_table_sources", "bikeshare_stations" ) }}.start_time > (SELECT MAX(start_time) FROM {{ this }})
-{% endif %}

--- a/models/example/stg_table_2.sql
+++ b/models/example/stg_table_2.sql
@@ -1,6 +1,6 @@
 {{ config(materialized='incremental') }}
 SELECT *
-FROM {{ source("test_table_sources", "table2" ) }}
+FROM {{ source("test_table_sources", "bikeshare_stations" ) }}
 {% if is_incremental() %}
-WHERE {{ source("test_table_sources", "table2" ) }}.timestamp > (SELECT MAX(timestamp) FROM {{ this }})
+WHERE {{ source("test_table_sources", "bikeshare_stations" ) }}.timestamp > (SELECT MAX(timestamp) FROM {{ this }})
 {% endif %}

--- a/models/example/stg_table_2.sql
+++ b/models/example/stg_table_2.sql
@@ -2,5 +2,5 @@
 SELECT *
 FROM {{ source("test_table_sources", "bikeshare_stations" ) }}
 {% if is_incremental() %}
-WHERE {{ source("test_table_sources", "bikeshare_stations" ) }}.timestamp > (SELECT MAX(timestamp) FROM {{ this }})
+WHERE {{ source("test_table_sources", "bikeshare_stations" ) }}.start_time > (SELECT MAX(start_time) FROM {{ this }})
 {% endif %}

--- a/models/marts/cur_stations.sql
+++ b/models/marts/cur_stations.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='incremental') }}
+SELECT *
+FROM {{ ref("stg_stations") }}
+{% if is_incremental() %}
+WHERE {{ ref("stg_stations") }}.start_time > (SELECT MAX(start_time) FROM {{ this }})
+{% endif %}

--- a/models/marts/cur_trips.sql
+++ b/models/marts/cur_trips.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='incremental') }}
+SELECT *
+FROM {{ ref("stg_trips") }}
+{% if is_incremental() %}
+WHERE {{ ref("stg_trips") }}.start_time > (SELECT MAX(start_time) from {{ this }})
+{% endif %}

--- a/models/staging/stg_stations.sql
+++ b/models/staging/stg_stations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='view') }}
+SELECT *
+FROM {{ source("test_table_sources", "bikeshare_stations" ) }}

--- a/models/staging/stg_trips.sql
+++ b/models/staging/stg_trips.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='view') }}
+SELECT *
+FROM {{ source("test_table_sources", "bikeshare_trips") }}

--- a/snapshots/test_snapshot.sql
+++ b/snapshots/test_snapshot.sql
@@ -7,7 +7,6 @@
           target_schema='test_snapshot',
         )
     }}
-    -- Pro-Tip: Use sources in snapshots!
-    -- select * from {{ source('test_table_sources', 'table1') }}
-    select * from {{ ref('stg_table_1') }}
+    select * from {{ source('test_table_sources', 'bikeshare_trips') }}
+    
 {% endsnapshot %}


### PR DESCRIPTION
This pull request includes significant changes to the database schema and data processing logic in the project. The changes involve updating table references, modifying materialization configurations, and altering the data sources to use public datasets.

### Database Schema and Data Sources:

* Updated `models/Untitled-1.sql` to comment out the creation and insertion of sample data into `table1` and `table2`, and added a query to select data from `bigquery-public-data.austin_311.311_service_requests`.
* Modified `models/example/schema.yml` to change the database and schema to `bigquery-public-data` and `austin_bikeshare`, respectively, and updated table names to `bikeshare_stations` and `bikeshare_trips`.

### Materialization and Incremental Logic:

* Added incremental materialization configuration to `models/marts/cur_stations.sql` and `models/marts/cur_trips.sql`. [[1]](diffhunk://#diff-a79e62666c70e340f953aeea480dce9262350a0e04035b3d6a57456d63db00bbR1-R6) [[2]](diffhunk://#diff-c62861f7b9708dbaf45f57dccb3e1fa3b8c6d77bd3a336a71e96fbb53f114e9dR1-R6)
* Removed incremental materialization logic from `models/example/stg_table_1.sql` and `models/example/stg_table_2.sql`. [[1]](diffhunk://#diff-6ceafbee6eba0638a526034fd90dc24a63cce158cadfe27c54c183435ad5a5b0L1-L7) [[2]](diffhunk://#diff-45e80fd24620ee8cf48f5560aa35794d6846624fc0b3a57a97a82ff850a786c1L1-L6)

### Staging and Snapshot Updates:

* Added view materialization configuration to `models/staging/stg_stations.sql` and `models/staging/stg_trips.sql`. [[1]](diffhunk://#diff-e668efe6b58ab20f63d40f1b3245567dbc5bfe0d458f987a33239086f866c785R1-R3) [[2]](diffhunk://#diff-b3d7a6bd206e4e15257a6594cd8e6e82e618598c2388cbd530bf642d4eaf8456R1-R3)
* Updated `snapshots/test_snapshot.sql` to use the `bikeshare_trips` source instead of `stg_table_1`.